### PR TITLE
Campaign lobby map images.

### DIFF
--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -885,10 +885,7 @@ namespace
 
 		if (name == 67196)
 		{
-			auto session = Blam::Network::GetActiveSession();
-
-			if (session && session->IsEstablished())
-				mapID = session->Parameters.MapVariant.MapID;
+			mapID = Pointer(0x18603F0).Read<uint32_t>();
 		}
 		else if (name == 67149)
 		{

--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -103,7 +103,7 @@ namespace
 	int GetBrokenChudStateFlags21Values();
 	int GetBrokenChudStateFlags31Values();
 	int GetBrokenChudStateFlags33Values();
-	void MenuSelectedMapIDChangedHook();
+	void c_gui_map_subitem_selectable_item_datasource__vftable01__player_select_actions();
 	void GetGlobalDynamicColorHook();
 	void GetWeaponOutlineColorHook();
 
@@ -300,7 +300,7 @@ namespace Patches::Ui
 		Pointer(0x016A6240).Write(uint32_t(&c_gui_bitmap_widget_update_render_data_hook));
 
 		//Fix map images in the selection menu.
-		Hook(0x6DA0FE, MenuSelectedMapIDChangedHook).Apply();
+		Hook(0x6DA0FE, c_gui_map_subitem_selectable_item_datasource__vftable01__player_select_actions).Apply();
 
 		// remove recent maps, fileshare menu items
 		Pointer(0x0169E270).Write(uint32_t(&c_gui_map_category_datasource_init));
@@ -852,7 +852,7 @@ namespace
 	}
 
 	unsigned int selectionMenuMapID = 0;
-	__declspec(naked) void MenuSelectedMapIDChangedHook()
+	__declspec(naked) void c_gui_map_subitem_selectable_item_datasource__vftable01__player_select_actions()
 	{
 		__asm
 		{
@@ -877,7 +877,7 @@ namespace
 		if (!foundMapImages)
 			return;
 
-		if (name != 67196 && name != 67149) // unknown_film_image, woohoo!
+		if (name != 67196 && name != 67149) // unknown_film_image, map_image_type
 			return;
 
 		static int bitmapIndex = 0;


### PR DESCRIPTION
Fixed a bug where map images weren't showing in pregame lobby 0.
This does not correct the level selection pane, which has many more issues (missing level descriptions, wrong level completion difficulties, no insertion point selection, locked level image...).

Tested across all lobbies.

Will need to make some tag changes for this them to show:

- in pregame_lobby_campaign.scn3.GroupWidgets[2].BitmapWidgets[0] set Name to unknown_film_image
- in start_menu_game_campaign.scn3.GroupWidgets[0].BitmapWidgets[0] set Name to unknown_film_image
- Make sure you have the images installed in gfxt (there's an installer in discord somewhere).