### PR TITLE
Default weapon fov fix, restore armor lights color

### DIFF
--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -792,6 +792,10 @@ namespace Patches::Core
 		// Fix default weapon fov value to match H3
 		Patch::NopFill(Pointer::Base(0x25FAB6), 8);
 		Patch(0x01913434, { 0xAE, 0x47, 0x61, 0x3F }).Apply();
+
+		// Fix spartan lights color, match primary as in H3
+		Patch(0x63CD03, { 0x8B, 0x00, 0x90 }).Apply();
+		Patch(0x63CD07, { 0x20 }).Apply();
 	}
 
 	void OnShutdown(ShutdownCallback callback)

--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -625,6 +625,10 @@ namespace Patches::Core
 		Patch(0x2EE51, { 0x0C }).Apply();
 		Patch(0x2EE54, { 0x14 }).Apply();
 
+		// Fix default weapon fov value to match H3
+		Patch::NopFill(Pointer::Base(0x25FAB6), 8);
+		Patch(0x01913434, { 0xAE, 0x47, 0x61, 0x3F }).Apply();
+
 		// Fix random colored lighting
 		Patch(0x14F2FFC, { 0x0, 0x0, 0x0, 0x0 }).Apply();
 

--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -625,10 +625,6 @@ namespace Patches::Core
 		Patch(0x2EE51, { 0x0C }).Apply();
 		Patch(0x2EE54, { 0x14 }).Apply();
 
-		// Fix default weapon fov value to match H3
-		Patch::NopFill(Pointer::Base(0x25FAB6), 8);
-		Patch(0x01913434, { 0xAE, 0x47, 0x61, 0x3F }).Apply();
-
 		// Fix random colored lighting
 		Patch(0x14F2FFC, { 0x0, 0x0, 0x0, 0x0 }).Apply();
 

--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -788,6 +788,10 @@ namespace Patches::Core
 
 		// campaign simulation hacks
 		//Hook(0x1A857B, simulation_player_left_game_hook).Apply(); // jmp, not call
+
+		// Fix default weapon fov value to match H3
+		Patch::NopFill(Pointer::Base(0x25FAB6), 8);
+		Patch(0x01913434, { 0xAE, 0x47, 0x61, 0x3F }).Apply();
 	}
 
 	void OnShutdown(ShutdownCallback callback)


### PR DESCRIPTION
Weapon fov now defaults to H3 value:
[Before](https://i.imgur.com/5ZfgAly.jpg)
[After](https://i.imgur.com/bPUA02d.jpg)

Restore mp_masterchief.rmsh self-illum color, simple cache edit also restores lights.rmsh color
[Before](https://i.imgur.com/cBkCe2f.jpg)
[After](https://i.imgur.com/j0KQUvV.jpg)